### PR TITLE
Redundant expression

### DIFF
--- a/lib/winston-postgresql.js
+++ b/lib/winston-postgresql.js
@@ -12,13 +12,13 @@ var PostgreSQL = exports.PostgreSQL = winston.transports.PostgreSQL = function(o
 
     options = options || {};
 
-    if(options.connString || "" != "") {
+    if(options.connString) {
         this.connString = options.connString;
     } else {
         throw new Error("PostgreSQL transport requires \"connString\".");
     }
 
-    if(options.tableName || options.customSql || "" != "") {
+    if(options.tableName || options.customSql) {
         this.sql = options.tableName ? 
             "INSERT INTO " + options.tableName + " (level, msg, meta) values ($1, $2, $3)" :
             options.customSql;


### PR DESCRIPTION
Line 15 and 21 both include a redundant expression in the `if` conditional branch `"" != ""` which will always return `false`, therefore it is not adding any value to the conditional expression if (`options.connString` || `options.connString` || `options.customSql`) is `undefined`